### PR TITLE
Refactor `getShortNameClass()` method to support optional `suffix` parameter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## 0.1.1 Under development
+## 0.1.2 February 29, 2024
+
+- Enh #4: Refactor `getShortNameClass()` method to support optional `suffix` parameter (@terabytesoftw)
 
 ## 0.1.1 February 29, 2024
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.1.2 February 29, 2024
 
-- Enh #4: Refactor `getShortNameClass()` method to support optional `suffix` parameter (@terabytesoftw)
+- Enh #4: Refactor `getShortNameClass()` method to support optional `suffix` and `lowercase` parameters (@terabytesoftw)
 
 ## 0.1.1 February 29, 2024
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,10 @@ The `Utils::class` helper can be used to get the short class name.
 The method accepts one parameter:
 
 - `class:` (string): The class name to get the short name.
+- `suffix:` (string): Whether to append the `::class` suffix to the class name. 
+  For default, it is `true`. If it is `false`, the method will return the short name without the `::class` suffix.
+- `lowercase:` (bool): Whether to convert the class name to lowercase or not. 
+  For default, it is `false`.
 
 ```php
 <?php
@@ -161,7 +165,7 @@ declare(strict_types=1);
 
 use PHPForge\Html\Helper\Utils;
 
-$shortName = Utils::getShortClassName('PHPForge\Html\Helper\Utils'); // return: `Utils`
+$shortName = Utils::getShortClassName('PHPForge\Html\Helper\Utils'); // return: `Utils::class`
 ```
 
 ### Generate arrayable name

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -155,10 +155,15 @@ final class Utils
      * Returns the short name of the given class.
      *
      * @param string $class The class name.
+     * @param bool|null $suffix Whether to append the `::class` suffix to the class name. If `null`, the suffix will not
+     * be appended.
      */
-    public static function getShortNameClass(string $class): string
+    public static function getShortNameClass(string $class, bool $suffix = true): string
     {
-        return substr(strrchr($class, '\\'), 1) . '::class';
+        return match($suffix) {
+            true => substr(strrchr($class, '\\'), 1) . '::class',
+            default => substr(strrchr($class, '\\'), 1),
+        };
     }
 
     /**

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -10,10 +10,12 @@ use UnexpectedValueException;
 use function mb_strtolower;
 use function preg_match;
 use function preg_replace;
+use function str_ends_with;
 use function str_replace;
 use function strlen;
 use function strrchr;
 use function strrpos;
+use function strtolower;
 use function substr;
 use function uniqid;
 
@@ -155,15 +157,20 @@ final class Utils
      * Returns the short name of the given class.
      *
      * @param string $class The class name.
-     * @param bool|null $suffix Whether to append the `::class` suffix to the class name. If `null`, the suffix will not
-     * be appended.
+     * @param bool $suffix Whether to append the `::class` suffix to the class name. If `false`, the suffix will not be
+     * appended.
+     * @param bool $lowercase Whether to return the class name in lowercase. If `false`, the class name will be returned
+     * in its original case.
      */
-    public static function getShortNameClass(string $class, bool $suffix = true): string
+    public static function getShortNameClass(string $class, bool $suffix = true, bool $lowercase = false): string
     {
-        return match($suffix) {
-            true => substr(strrchr($class, '\\'), 1) . '::class',
-            default => substr(strrchr($class, '\\'), 1),
-        };
+        if ($lowercase === true) {
+            $class = strtolower($class);
+        }
+
+        $class = substr(strrchr($class, '\\'), 1);
+
+        return $suffix === true ? "$class::class" : $class;
     }
 
     /**

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -95,6 +95,11 @@ final class UtilsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('UtilsTest::class', Utils::getShortNameClass(self::class));
     }
 
+    public function testGetShortNameClassWithLowercase(): void
+    {
+        $this->assertSame('utilstest', Utils::getShortNameClass(self::class, false, true));
+    }
+
     public function testGetShortNameClassWithoutSuffix(): void
     {
         $this->assertSame('UtilsTest', Utils::getShortNameClass(self::class, false));

--- a/tests/UtilsTest.php
+++ b/tests/UtilsTest.php
@@ -95,6 +95,11 @@ final class UtilsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('UtilsTest::class', Utils::getShortNameClass(self::class));
     }
 
+    public function testGetShortNameClassWithoutSuffix(): void
+    {
+        $this->assertSame('UtilsTest', Utils::getShortNameClass(self::class, false));
+    }
+
     public function testMultibyteGenerateArrayableName(): void
     {
         $this->assertSame('登录[]', Utils::generateArrayableName('登录'));


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Breaks BC?    | ❌
