### PR TITLE
Add 'formaction' to list of evil attributes to remove in `Sanitize:class` helper.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.2.2 Under development
 
+- Bug #9: Add 'formaction' to list of evil attributes to remove in `Sanitize::class` helper (@terabytesoftw)
+
 ## 0.2.1 March 2, 2024
 
 - Bug #7: Update branch alias in `composer.json` (@terabytesoftw)

--- a/src/Sanitize.php
+++ b/src/Sanitize.php
@@ -17,6 +17,7 @@ final class Sanitize
      */
     private static array $removeEvilAttributes = [
         'form',
+        'formaction',
         'style',
     ];
     /**


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
